### PR TITLE
GTK and terminal off by one fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -357,7 +357,7 @@ run.shallow: iso.shallow disk.shallow
 		-boot d \
 		-cdrom $(ISO_FILE) \
 		-drive file=$(DISK),format=raw,index=0,media=disk \
-		-display sdl \
+		-display gtk \
 		-monitor stdio
 
 run: iso disk
@@ -366,7 +366,7 @@ run: iso disk
 		-boot d \
 		-cdrom $(ISO_FILE) \
 		-drive file=$(DISK),format=raw,index=0,media=disk \
-		-display sdl \
+		-display gtk \
 		-monitor stdio
 
 .PHONY: clean

--- a/src/k_startup/src/plugin_gfx.c
+++ b/src/k_startup/src/plugin_gfx.c
@@ -270,12 +270,11 @@ static void tw_render(window_t *w) {
 
         const gfx_color_t term_border_color = win_t->tb_attrs.palette.colors[TC_LIGHT_GREY];
 
-        // Draw borders!
         gfx_fill_rect(&buf, NULL, 0, 0, buf.width, tb_y, term_border_color); 
-        gfx_fill_rect(&buf, NULL, 0,  buf.height - tb_y, buf.width, tb_y, term_border_color); 
+        gfx_fill_rect(&buf, NULL, 0, tb_y + tb_height, buf.width, buf.height - (tb_y + tb_height), term_border_color); 
 
         gfx_fill_rect(&buf, NULL, 0, tb_y, tb_x, tb_height, term_border_color);
-        gfx_fill_rect(&buf, NULL, buf.width - tb_x, tb_y, tb_x, tb_height, term_border_color);
+        gfx_fill_rect(&buf, NULL, tb_x + tb_width, tb_y, buf.width - (tb_x + tb_width), tb_height, term_border_color);
         
         win_t->just_resized = false;
     }


### PR DESCRIPTION
I realized that how I was rendering the border for my terminal window allowed for an off by one error.

i.e. I was doing division by 2 of an odd number. My rendering resulted in a 1px wide gap between borders.