### PR TITLE
Make stub hard argument requirement

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -106,11 +106,15 @@ $(OS_DEFS_S): $(THIS_FIE) | $(INCLUDE_DIR)
 
 ####################################################################################################
 
+# A helper macro invoking module specific make targets!
+# This expects that $* resolves to the name of a module.
+MOD_MAKE = $(MY_MAKE) -C $(SRC_DIR)/$* BUILD_DIR=$(BUILD_DIR)/mods/$* INSTALL_DIR=$(INSTALL_DIR)
+
 # Install Headers
 
 INCLUDE_DIRS := $(addprefix $(INCLUDE_DIR)/,$(MODS))
 $(INCLUDE_DIRS): $(INCLUDE_DIR)/%: | $(INCLUDE_DIR)
-	$(MY_MAKE) -C $(SRC_DIR)/$* hdrs.install test_hdrs.install 
+	$(MOD_MAKE) hdrs.install test_hdrs.install 
 
 ALL_INCLUDES := $(INCLUDE_DIRS) $(OS_DEFS_H) $(OS_DEFS_S)
 
@@ -124,7 +128,7 @@ hdrs.install.shallow: $(ALL_INCLUDES)
 # check for modification!
 HDRS_INSTALL_TARS := $(addprefix hdrs.install.,$(MODS))
 $(HDRS_INSTALL_TARS): hdrs.install.%:
-	$(MY_MAKE) -C $(SRC_DIR)/$* hdrs.install test_hdrs.install 
+	$(MOD_MAKE) hdrs.install test_hdrs.install 
 
 .PHONY: hdrs.install $(HDRS_INSTALL_TARS)
 hdrs.install: $(HDRS_INSTALL_TARS) $(OS_DEFS_H) $(OS_DEFS_S)
@@ -135,11 +139,11 @@ hdrs.install: $(HDRS_INSTALL_TARS) $(OS_DEFS_H) $(OS_DEFS_S)
 # NOTE: The LIBS and TEST_LIBS targets are Shallow since they ONLY CHECK FOR EXISTENCE!!!
 LIBS := $(patsubst %,$(INSTALL_DIR)/lib%.a,$(MODS))
 $(LIBS): $(INSTALL_DIR)/lib%.a: | $(ALL_INCLUDES)
-	$(MY_MAKE) -C $(SRC_DIR)/$* lib.install
+	$(MOD_MAKE) lib.install
 
 TEST_LIBS := $(patsubst %,$(INSTALL_DIR)/lib%_test.a,$(MODS))
-$(TEST_LIBS): $(INSTALL_DIR)/lib%_test.a: | $(INSTALL_DIR) $(ALL_INCLUDES)
-	$(MY_MAKE) -C $(SRC_DIR)/$* test_lib.install
+$(TEST_LIBS): $(INSTALL_DIR)/lib%_test.a: | $(ALL_INCLUDES)
+	$(MOD_MAKE) test_lib.install
 
 ALL_LIBS := $(LIBS) $(TEST_LIBS)
 
@@ -155,7 +159,7 @@ LIB_INSTALL_TARS := $(addprefix lib.install.,$(MODS))
 # This is "unsafe" since there is no gaurantee that the headers have been installed.
 lib.unsafe_install: $(LIB_INSTALL_TARS)
 $(LIB_INSTALL_TARS): lib.install.%:
-	$(MY_MAKE) -C $(SRC_DIR)/$* lib.install test_lib.install
+	$(MOD_MAKE) lib.install test_lib.install
 
 lib.install: hdrs.install
 	$(MY_MAKE) -C $(SRC_DIR) lib.unsafe_install
@@ -167,7 +171,7 @@ CLANGD_TARS := $(addprefix clangd.,$(MODS))
 .PHONY: clangd $(CLANGD_TARS)
 
 $(CLANGD_TARS): clangd.%:
-	$(MY_MAKE) -C $(SRC_DIR)/$* clangd
+	$(MOD_MAKE) clangd
 
 clangd: $(CLANGD_TARS)
 	$(call DONE_MSG,Clangd Installed)
@@ -176,7 +180,7 @@ CLANGD_CLEAN_TARS := $(addprefix clean.clangd.,$(MODS))
 .PHONY: clean.clangd $(CLANGD_CLEAN_TARS)
 
 $(CLANGD_CLEAN_TARS): clean.clangd.%:
-	$(MY_MAKE) -C $(SRC_DIR)/$* clean.clangd
+	$(MOD_MAKE) clean.clangd
 
 clean.clangd: $(CLANGD_CLEAN_TARS)
 	$(call DONE_MSG,Clang Cleaned)

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ MODS := \
 
 # Static memory layout header and linker generation:
 
-$(INCLUDE_DIR) $(INSTALL_DIR):
+$(BUILD_DIR) $(INCLUDE_DIR) $(INSTALL_DIR):
 	mkdir -p $@
 
 ####################################################################################################
@@ -197,15 +197,16 @@ LDSCRIPT := $(SRC_DIR)/linker.ld
 ELF_FILE := $(BUILD_DIR)/$(OS_NAME).elf
 ELF_SYMS := $(BUILD_DIR)/$(OS_NAME).syms
 
-$(BUILD_DIR):
-	mkdir -p $@
-
 LIB_FLAGS := $(foreach mod,$(MODS),-l$(mod)_test -l$(mod))
 
 # Remember this will not attempt to rebuild libs if they already exist!
 $(ELF_FILE): $(ALL_LIBS) $(OS_DEFS_LD) | $(BUILD_DIR)
 	$(C_COMPILER) -T $(LDSCRIPT) -o $@ -ffreestanding -nostdlib -O2 -L$(INSTALL_DIR) \
 		-Wl,--start-group -lgcc -Wl,--whole-archive $(LIB_FLAGS) -Wl,--end-group 
+
+# The symbols file is useful for compiling user application binaries.  (Depends on SHALLOW kernel rules)
+$(ELF_SYMS): $(ELF_FILE) | $(BUILD_DIR)
+	i686-elf-objcopy --extract-symbol $(ELF_FILE) $@
 
 .PHONY: elf.shallow elf.shallow.dummy
 elf.shallow.dummy: $(ELF_FILE)
@@ -223,40 +224,36 @@ elf: lib.install $(OS_DEFS_LD)
 # User Apps
 
 # NOTE: ADD APPLICATION NAMES HERE!
-APPS := Test \
+_APPS := Test \
 		Shell
 
 APPS_DIR  := $(SRC_DIR)/apps
 
-APPS_BUILD := $(BUILD_DIR)/apps
-APPS_OUT := $(BUILD_DIR)/apps/out
+APPS_BUILD := $(BUILD_DIR)/apps/build
+APPS_OUT := $(BUILD_DIR)/apps/bin
 
-# The symbols file is useful for compiling user application binaries.  (Depends on SHALLOW kernel rules)
-$(ELF_SYMS): $(ELF_FILE) | $(BUILD_DIR)
-	i686-elf-objcopy --extract-symbol $(ELF_FILE) $@
+APPS := $(addprefix $(APPS_OUT)/,$(_APPS))
 
-$(APPS_BUILD) $(APPS_OUT):
-	mkdir -p $@
+# Similar to MOD_MAKE macro, but for apps
+APP_MAKE = $(MY_MAKE) -C $(APPS_DIR)/$* \
+				BUILD_DIR=$(APPS_BUILD)/$* \
+				OUT_DIR=$(APPS_OUT) \
+				INSTALL_DIR=$(INSTALL_DIR) \
+				ELF_SYMS=$(ELF_SYMS) 
 
-APP_BUILDS := $(addprefix $(APPS_BUILD)/,$(APPS))
-
-$(APP_BUILDS): $(APPS_BUILD)/%: $(ELF_SYMS) | $(APPS_BUILD) $(APPS_OUT)
-	$(MY_MAKE) -C $(APPS_DIR)/$* \
-		BUILD_DIR=$@ \
-		OUT_DIR=$(APPS_OUT) \
-		INSTALL_DIR=$(INSTALL_DIR) \
-		ELF_SYMS=$(ELF_SYMS) \
-		bin
+.PHONY: $(APPS)
+$(APPS): $(APPS_OUT)/%: $(ELF_SYMS)
+	$(APP_MAKE) bin
 
 # NOTE: VERY IMPORTANT!
 # Apps specific makefile are always invoked! However, the shallow/unshallow rules below determine
 # whether or not the kernel is rebuilt first!
 
-.PHONY: apps.shallow apps.shallow.dummy $(APP_BUILDS)
-apps.shallow.dummy: $(APP_BUILDS)
+.PHONY: apps.shallow apps.shallow.dummy
+apps.shallow.dummy: $(APPS)
 	@echo > /dev/null
 
-apps.shallow: $(APP_BUILDS)
+apps.shallow: $(APPS)
 	$(call DONE_MSG,Apps Built [shallow kernel])
 
 .PHONY: apps
@@ -266,23 +263,20 @@ apps: elf
 
 # Potentially move this out of here?
 
-APPS_CLANGD_TARS := $(addprefix apps.clangd.,$(APPS))
+APPS_CLANGD_TARS := $(addprefix apps.clangd.,$(_APPS))
 .PHONY: apps.clangd $(APPS_CLANGD_TARS)
 
 $(APPS_CLANGD_TARS): apps.clangd.%: 
-	$(MY_MAKE) -C $(APPS_DIR)/$* \
-		INSTALL_DIR=$(INSTALL_DIR) \
-		clangd
+	$(APP_MAKE) clangd
 
 apps.clangd: $(APPS_CLANGD_TARS)
 	$(call DONE_MSG,App Clangd Installed)
 
-APPS_CLEAN_CLANGD_TARS := $(addprefix apps.clean.clangd.,$(APPS))
+APPS_CLEAN_CLANGD_TARS := $(addprefix apps.clean.clangd.,$(_APPS))
 .PHONY: apps.clean.clangd $(APPS_CLEAN_CLANGD_TARS)
 
 $(APPS_CLEAN_CLANGD_TARS): apps.clean.clangd.%:
-	$(MY_MAKE) -C $(APPS_DIR)/$* \
-		clean.clangd
+	$(APP_MAKE) clean.clangd
 
 apps.clean.clangd: $(APPS_CLEAN_CLANGD_TARS)
 	$(call DONE_MSG,App Clangd Cleaned)
@@ -336,7 +330,7 @@ iso: elf
 
 DISK := $(BUILD_DIR)/hdd.img
 
-$(DISK): $(APP_BUILDS) | $(BUILD_DIR)
+$(DISK): $(APPS) | $(BUILD_DIR)
 	qemu-img create -f raw $@ 256M
 	mkfs.fat -F 32 -s 2 $@
 	mcopy -i $@ $(APPS_OUT) ::/Bin

--- a/src/apps/app_stub.mk
+++ b/src/apps/app_stub.mk
@@ -13,7 +13,9 @@
 # REQUIRED
 #
 # The name of this application. MUST be the same as this apps directory name.
-APP_NAME ?=
+ifeq ($(APP_NAME),)
+$(error App specified with no app name)
+endif
 
 # REQUIRED
 #
@@ -28,23 +30,31 @@ _SRCS ?=
 # REQUIRED
 #
 # Where to place intermediary build artifacts
-BUILD_DIR ?=
+ifeq ($(BUILD_DIR),)
+$(error $(APP_NAME) has no build directory specified)
+endif
 
 # REQUIRED
 #
 # Where to place final binary
-OUT_DIR ?=
+ifeq ($(OUT_DIR),)
+$(error $(APP_NAME) has no out directory specified)
+endif
 
 # REQUIRED
 #
 # Where FernOS built libraries and copied headers are placed. (MUST EXIST)
 # NOTE: We expect the INCLUDE_DIR to be at $(INSTALL_DIR)/include
-INSTALL_DIR ?=
+ifeq ($(INSTALL_DIR),)
+$(error $(APP_NAME) has no install directory specified)
+endif
 
 # REQUIRED
 #
 # ELF Symbols file. (MUST EXIST)
-ELF_SYMS ?=
+ifeq ($(ELF_SYMS),)
+$(error $(APP_NAME) has no elf symbols file specified)
+endif
 
 ####################################################################################################
 
@@ -69,7 +79,7 @@ $(OBJS): $(BUILD_DIR)/%.o: $(APP_DIR)/%.c $(ELF_SYMS) | $(BUILD_DIR)
 
 # NOTE: in the below recipe we give -L$(INSTALL_DIR) so we have access to os_defs.ld
 # This recipe DOES NOT use any FernOS libraries directly! (The point of the symbols file)
-$(APP): $(OBJS) | $(BUILD_DIR)
+$(APP): $(OBJS) | $(OUT_DIR)
 	$(C_COMPILER) -T $(APP_LDSCRIPT) -o $@ -ffreestanding -O2 -nostdlib -L$(INSTALL_DIR) \
 	    -lgcc -Wl,--just-symbols=$(ELF_SYMS) $^
 

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -1,8 +1,9 @@
 # NOTE: This stub is meant to be included
-GIT_TOP ?= $(shell git rev-parse --show-toplevel)
 
 # REQUIRED: Name of the standalone module (MUST BE THE SAME AS IT"S DIRECTORY NAME)
-MOD_NAME 	?=
+ifeq ($(MOD_NAME),)
+$(error module name is required)
+endif
 
 # REQUIRED: Names (NOT PATHS) of all .c files found in the src folder
 _SRCS 		?=
@@ -13,16 +14,22 @@ _ASMS		?=
 # REQUIRED: Names (NOT PATHS) of all .c files in the test folder
 _TEST_SRCS 	?=
 
-# OPTIONAL: Where to place build artifacts
-BUILD_DIR   ?= $(GIT_TOP)/src/build/mods/$(MOD_NAME)
+# REQUIRED: Where to place build artifacts
+ifeq ($(BUILD_DIR),)
+$(error $(MOD_NAME) requires build directory to build)
+endif
 
-# OPTIONAL: Where to place .a files and headers
-INSTALL_DIR ?= $(GIT_TOP)/src/build/install
+# REQUIRED: Where to place .a files and headers
+ifeq ($(INSTALL_DIR),)
+$(error $(MOD_NAME) requires install dir to build)
+endif
 
 # OPTIONAL: Extra C flags to use
 EXTRA_CFLAGS ?=
 
 #####################################################################################
+
+GIT_TOP := $(shell git rev-parse --show-toplevel)
 
 # I think it's safe to say that for the entirety of this project I'll be using
 # the 386 tools.


### PR DESCRIPTION
Previously applications and modules would use stub makefiles with `?=` default values for certain inputs.

The purpose was that I could call `make -C <module_dir> <target>` without needing to pass a bunch of make command line definitions. At first this was nice, but I have grown to dislike this style of defaults. In my opinion, whenever invoking one makefile from another, ALL expected arguments should be passed as command line definitions. This way they cannot be overriden unintentionally. 

