### PR TITLE
Make Refactor with .d files!

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -130,7 +130,7 @@ $(OS_DEFS_LD): $(THIS_FILE) | $(INSTALL_DIR)
 	$(foreach def,$(OS_DEFS),$(call LD_DEF_GEN,$(def)))
 
 OS_DEFS_S := $(INCLUDE_DIR)/s_os_defs.h
-$(OS_DEFS_S): $(THIS_FIE) | $(INCLUDE_DIR)
+$(OS_DEFS_S): $(THIS_FILE) | $(INCLUDE_DIR)
 	rm $@; touch $@;
 	$(foreach def,$(OS_DEFS),$(call S_DEF_GEN,$(def)))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -110,6 +110,14 @@ $(OS_DEFS_S): $(THIS_FIE) | $(INCLUDE_DIR)
 # This expects that $* resolves to the name of a module.
 MOD_MAKE = $(MY_MAKE) -C $(SRC_DIR)/$* BUILD_DIR=$(BUILD_DIR)/mods/$* INSTALL_DIR=$(INSTALL_DIR)
 
+DOTDS_TARS := $(addprefix lib.dotds.,$(MODS))
+$(DOTDS_TARS): lib.dotds.%:
+	$(MOD_MAKE) lib.dotds test_lib.dotds
+
+.PHONY: lib.dotds $(DOTDS_TARS)
+lib.dotds: $(DOTDS_TARS)
+	$(call DONE_MSG,.d Files Generated)
+
 # Install Headers
 
 INCLUDE_DIRS := $(addprefix $(INCLUDE_DIR)/,$(MODS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,34 @@
 
+# The below diagram outlines the most significant targets of this Makefile and their relationships!
+#
+# Certain targets are actually built entirely in this Makefile. For example the disk, iso, and elf.
+# While others require invoking other Makefiles! For example hdrs.install, lib.install, and apps
+
+####### DEPENDENCY GRAPH OVERVIEW #######
+# 										#
+#                hdrs.install 			#
+# 	                  | 				#
+#                     V 				#
+#                lib.install 			#         
+# 	                  | 				#
+#                     V 				#
+#                    elf 				#
+#                     | 				#
+#            ---------* 				#
+#            |        | 				#
+#            V        | 				#
+#           apps      V 				#
+#            |       iso  				#
+#            V        | 				#
+#           disk      |  				#
+#            |        V 				#
+#            *-----> run  				#
+# 										#
+#########################################
+
+####################################################################################################
+
+
 GIT_TOP ?= $(shell git rev-parse --show-toplevel)
 
 SRC_DIR    := $(GIT_TOP)/src
@@ -110,27 +140,7 @@ $(OS_DEFS_S): $(THIS_FIE) | $(INCLUDE_DIR)
 # This expects that $* resolves to the name of a module.
 MOD_MAKE = $(MY_MAKE) -C $(SRC_DIR)/$* BUILD_DIR=$(BUILD_DIR)/mods/$* INSTALL_DIR=$(INSTALL_DIR)
 
-DOTDS_TARS := $(addprefix lib.dotds.,$(MODS))
-$(DOTDS_TARS): lib.dotds.%:
-	$(MOD_MAKE) lib.dotds test_lib.dotds
-
-.PHONY: lib.dotds $(DOTDS_TARS)
-lib.dotds: $(DOTDS_TARS)
-	$(call DONE_MSG,.d Files Generated)
-
 # Install Headers
-
-INCLUDE_DIRS := $(addprefix $(INCLUDE_DIR)/,$(MODS))
-$(INCLUDE_DIRS): $(INCLUDE_DIR)/%: | $(INCLUDE_DIR)
-	$(MOD_MAKE) hdrs.install test_hdrs.install 
-
-ALL_INCLUDES := $(INCLUDE_DIRS) $(OS_DEFS_H) $(OS_DEFS_S)
-
-# NOTE: This target is "shallow" because it doesn't check for modifications at all.
-# If the include directories exist, it does NOTHING!
-.PHONY: hdrs.install.shallow
-hdrs.install.shallow: $(ALL_INCLUDES)
-	$(call DONE_MSG,Headers Installed [shallow])
 
 # These targets are NOT "shallow" since they always defer to the module makefile which DOES
 # check for modification!
@@ -144,31 +154,19 @@ hdrs.install: $(HDRS_INSTALL_TARS) $(OS_DEFS_H) $(OS_DEFS_S)
 
 # Install Libraries
 
-# NOTE: The LIBS and TEST_LIBS targets are Shallow since they ONLY CHECK FOR EXISTENCE!!!
 LIBS := $(patsubst %,$(INSTALL_DIR)/lib%.a,$(MODS))
-$(LIBS): $(INSTALL_DIR)/lib%.a: | $(ALL_INCLUDES)
-	$(MOD_MAKE) lib.install
-
 TEST_LIBS := $(patsubst %,$(INSTALL_DIR)/lib%_test.a,$(MODS))
-$(TEST_LIBS): $(INSTALL_DIR)/lib%_test.a: | $(ALL_INCLUDES)
-	$(MOD_MAKE) test_lib.install
-
 ALL_LIBS := $(LIBS) $(TEST_LIBS)
 
-.PHONY: lib.install.shallow
-lib.install.shallow: $(ALL_LIBS)
-	$(call DONE_MSG,Libraries Installed [shallow])
-
-# Install Libs (For now we'll just always build the test and normal libs)
-
-LIB_INSTALL_TARS := $(addprefix lib.install.,$(MODS))
+LIB_INSTALL_TARS := $(addprefix lib.unsafe_install.,$(MODS))
 .PHONY: lib.unsafe_install lib.install $(LIB_INSTALL_TARS)
 
 # This is "unsafe" since there is no gaurantee that the headers have been installed.
-lib.unsafe_install: $(LIB_INSTALL_TARS)
-$(LIB_INSTALL_TARS): lib.install.%:
+$(LIB_INSTALL_TARS): lib.unsafe_install.%:
 	$(MOD_MAKE) lib.install test_lib.install
+lib.unsafe_install: $(LIB_INSTALL_TARS)
 
+# This is safe becuase we gaurantee headers are installed first!
 lib.install: hdrs.install
 	$(MY_MAKE) -C $(SRC_DIR) lib.unsafe_install
 	$(call DONE_MSG,Libraries Installed)
@@ -207,7 +205,8 @@ ELF_SYMS := $(BUILD_DIR)/$(OS_NAME).syms
 
 LIB_FLAGS := $(foreach mod,$(MODS),-l$(mod)_test -l$(mod))
 
-# Remember this will not attempt to rebuild libs if they already exist!
+# Realize that ALL_LIBS doesn't actually define a rule for itself. This ELF target should NEVER
+# be invoked without libs already being explicity installed previously!
 $(ELF_FILE): $(ALL_LIBS) $(OS_DEFS_LD) | $(BUILD_DIR)
 	$(C_COMPILER) -T $(LDSCRIPT) -o $@ -ffreestanding -nostdlib -O2 -L$(INSTALL_DIR) \
 		-Wl,--start-group -lgcc -Wl,--whole-archive $(LIB_FLAGS) -Wl,--end-group 
@@ -216,15 +215,13 @@ $(ELF_FILE): $(ALL_LIBS) $(OS_DEFS_LD) | $(BUILD_DIR)
 $(ELF_SYMS): $(ELF_FILE) | $(BUILD_DIR)
 	i686-elf-objcopy --extract-symbol $(ELF_FILE) $@
 
-.PHONY: elf.shallow elf.shallow.dummy
-elf.shallow.dummy: $(ELF_FILE)
+.PHONY: elf.unsafe
+elf.unsafe: $(ELF_FILE) $(ELF_SYMS)
 	@echo > /dev/null
-elf.shallow: $(ELF_FILE)
-	$(call DONE_MSG,Kernel ELF Built [shallow])
 
 .PHONY: elf
-elf: lib.install $(OS_DEFS_LD)
-	$(MY_MAKE) -C $(SRC_DIR) elf.shallow.dummy
+elf: lib.install
+	$(MY_MAKE) -C $(SRC_DIR) elf.unsafe
 	$(call DONE_MSG,Kernel ELF Built)
 
 ####################################################################################################
@@ -249,24 +246,17 @@ APP_MAKE = $(MY_MAKE) -C $(APPS_DIR)/$* \
 				INSTALL_DIR=$(INSTALL_DIR) \
 				ELF_SYMS=$(ELF_SYMS) 
 
-.PHONY: $(APPS)
-$(APPS): $(APPS_OUT)/%: $(ELF_SYMS)
+APP_TARS := $(addprefix apps.unsafe.,$(_APPS))
+.PHONY: apps.unsafe $(APP_TARS)
+
+$(APP_TARS): apps.unsafe.%:
 	$(APP_MAKE) bin
 
-# NOTE: VERY IMPORTANT!
-# Apps specific makefile are always invoked! However, the shallow/unshallow rules below determine
-# whether or not the kernel is rebuilt first!
-
-.PHONY: apps.shallow apps.shallow.dummy
-apps.shallow.dummy: $(APPS)
-	@echo > /dev/null
-
-apps.shallow: $(APPS)
-	$(call DONE_MSG,Apps Built [shallow kernel])
+apps.unsafe: $(APP_TARS)
 
 .PHONY: apps
 apps: elf
-	$(MY_MAKE) -C $(SRC_DIR) apps.shallow.dummy
+	$(MY_MAKE) -C $(SRC_DIR) apps.unsafe
 	$(call DONE_MSG,Apps Built)
 
 # Potentially move this out of here?
@@ -293,7 +283,6 @@ apps.clean.clangd: $(APPS_CLEAN_CLANGD_TARS)
 
 # ISO File (Soon disk setup will be swallowed by this section)
 
-
 ISO_DIR  := $(BUILD_DIR)/iso
 GRUB_CFG := $(SRC_DIR)/grub.cfg
 ISO_FILE := $(BUILD_DIR)/$(OS_NAME).iso
@@ -308,16 +297,13 @@ $(ISO_FILE): $(ELF_FILE) $(GRUB_CFG)
 	cp $(GRUB_CFG) $(ISO_DIR)/boot/grub/
 	grub-mkrescue -o $@ $(ISO_DIR)
 
-.PHONY: _iso iso.shallow iso
+.PHONY: iso.unsafe iso
 
-_iso: $(ISO_FILE)
+iso.unsafe: $(ISO_FILE)
 	@echo > /dev/null
 
-iso.shallow: _iso
-	$(call DONE_MSG,ISO Built [shallow kernel])
-
 iso: elf
-	$(MY_MAKE) -C $(SRC_DIR) _iso
+	$(MY_MAKE) -C $(SRC_DIR) iso.unsafe
 	$(call DONE_MSG,ISO Built)
 
 ####################################################################################################
@@ -343,12 +329,12 @@ $(DISK): $(APPS) | $(BUILD_DIR)
 	mkfs.fat -F 32 -s 2 $@
 	mcopy -i $@ $(APPS_OUT) ::/Bin
 
-.PHONY: disk disk.shallow 
-disk.shallow: $(DISK)
-	$(call DONE_MSG,Disk Built [shallow kernel])
+.PHONY: disk disk.unsafe
+disk.unsafe: $(DISK)
+	@echo > /dev/null
 
-disk: elf
-	$(MY_MAKE) -C $(SRC_DIR) $(DISK)
+disk: apps
+	$(MY_MAKE) -C $(SRC_DIR) disk.unsafe
 	$(call DONE_MSG,Disk Built)
 
 ####################################################################################################
@@ -356,15 +342,6 @@ disk: elf
 # Bringing it all together
 
 .PHONY: run run.shallow
-
-run.shallow: iso.shallow disk.shallow
-	qemu-system-x86_64 \
-		-m 4G \
-		-boot d \
-		-cdrom $(ISO_FILE) \
-		-drive file=$(DISK),format=raw,index=0,media=disk \
-		-display gtk \
-		-monitor stdio
 
 run: iso disk
 	qemu-system-x86_64 \
@@ -379,5 +356,4 @@ run: iso disk
 
 clean:
 	rm -rf $(BUILD_DIR)
-	rm -f $(OS_DEFS_LD)
 

--- a/src/apps/Shell/app_main.c
+++ b/src/apps/Shell/app_main.c
@@ -7,7 +7,6 @@
 #include <stddef.h>
 #include "s_util/ps2_scancodes.h"
 
-
 /*
  * NOTE: Probably going to come back to this after graphics!
  */

--- a/src/apps/app_stub.mk
+++ b/src/apps/app_stub.mk
@@ -63,25 +63,42 @@ SRC_DIR := $(GIT_TOP)/src
 APP_LDSCRIPT  := $(SRC_DIR)/linker_app.ld
 INCLUDE_DIR   := $(INSTALL_DIR)/include
 APP_DIR := $(SRC_DIR)/apps/$(APP_NAME)
+INCLUDE_FLAGS := -I$(APP_DIR) -I$(INCLUDE_DIR)
 APP := $(OUT_DIR)/$(APP_NAME)
 
 C_COMPILER := i686-elf-gcc
 
+SRCS := $(addprefix $(APP_DIR)/,$(_SRCS))
+
+DOTDS 	:= $(patsubst %.c,$(BUILD_DIR)/%.d,$(_SRCS))
+OBJS 	:= $(patsubst %.c,$(BUILD_DIR)/%.o,$(_SRCS))
+
+# This stub is similar to mod_stub.mk (just a little simpler)
+# To generate the .d files, all referenced headers MUST be installed!
+
 $(BUILD_DIR) $(OUT_DIR):
 	mkdir -p $@
 
-SRCS := $(addprefix $(APP_DIR)/,$(_SRCS))
-OBJS := $(patsubst %.c, $(BUILD_DIR)/%.o,$(_SRCS))
+$(DOTDS): $(BUILD_DIR)/%.d: $(APP_DIR)/%.c | $(BUILD_DIR)
+	$(C_COMPILER) $(INCLUDE_FLAGS) -E $< -MM -MT "$(BUILD_DIR)/$*.o" -MF $@
 
+.PHONY: dotds
+dotds: $(DOTDS)
+
+ifneq ($(filter bin,$(MAKECMDGOALS)),)
+include $(DOTDS)
+endif
+
+# We rebuild an object if any of its source file or referenced headers change (using .d files)
 CFLAGS := -m32 -std=gnu99 -ffreestanding -Wall -Wextra -Wpedantic 
-$(OBJS): $(BUILD_DIR)/%.o: $(APP_DIR)/%.c $(ELF_SYMS) | $(BUILD_DIR)
+$(OBJS): $(BUILD_DIR)/%.o: | $(BUILD_DIR)
 	$(C_COMPILER) -c $(CFLAGS) -I$(INCLUDE_DIR) -I$(APP_DIR) -o $@ $<
 
 # NOTE: in the below recipe we give -L$(INSTALL_DIR) so we have access to os_defs.ld
 # This recipe DOES NOT use any FernOS libraries directly! (The point of the symbols file)
-$(APP): $(OBJS) | $(OUT_DIR)
+$(APP): $(OBJS) $(ELF_SYMS) | $(OUT_DIR)
 	$(C_COMPILER) -T $(APP_LDSCRIPT) -o $@ -ffreestanding -O2 -nostdlib -L$(INSTALL_DIR) \
-	    -lgcc -Wl,--just-symbols=$(ELF_SYMS) $^
+	    -lgcc -Wl,--just-symbols=$(ELF_SYMS) $(OBJS)
 
 .PHONY: bin
 bin: $(APP)

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -31,8 +31,6 @@ EXTRA_CFLAGS ?=
 
 GIT_TOP := $(shell git rev-parse --show-toplevel)
 
-# I think it's safe to say that for the entirety of this project I'll be using
-# the 386 tools.
 C_COMPILER := i686-elf-gcc
 AR 		   := i686-elf-ar
 
@@ -48,7 +46,7 @@ INSTALL_INC_DIR := $(INSTALL_DIR)/include
 
 # NOTE: 
 # SRC_INC_DIRS, and TEST_INC_DIRS used to both include $(INC_DIR) before
-# $(INSTALL_INC_DIR). The intention was that during compilation this modules headers in the
+# $(INSTALL_INC_DIR). The intention was that during compilation this module's headers in the
 # source tree would take precedence over its own headers which live in the install tree!
 #
 # When switching over to using .d files though, this file now requires that hdrs.install

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -46,20 +46,29 @@ MODS_DIR := $(GIT_TOP)/src
 MOD_DIR := $(MODS_DIR)/$(MOD_NAME)
 INSTALL_INC_DIR := $(INSTALL_DIR)/include
 
+# NOTE: 
+# SRC_INC_DIRS, and TEST_INC_DIRS used to both include $(INC_DIR) before
+# $(INSTALL_INC_DIR). The intention was that during compilation this modules headers in the
+# source tree would take precedence over its own headers which live in the install tree!
+#
+# When switching over to using .d files though, this file now requires that hdrs.install
+# is called on the top level Makefile before any lib building targets are called via this file.
+#
+# This means, if you call a lib.install at the top level, it will gaurantee that all hdrs in 
+# install are up to date before attempting any compilation!
+
 INC_DIR		 := $(MOD_DIR)/include
-INC_INC_DIRS := $(INC_DIR) $(INSTALL_INC_DIR)
-INC_INC_FLAGS:= $(addprefix -I,$(INC_INC_DIRS))
 HDRS	 	 := $(wildcard $(INC_DIR)/$(MOD_NAME)/*.h)
 TEST_HDRS	 := $(wildcard $(INC_DIR)/$(MOD_NAME)/test/*.h)
 
 SRC_DIR 	 := $(MOD_DIR)/src
-SRC_INC_DIRS := $(SRC_DIR) $(INC_DIR) $(INSTALL_INC_DIR)
+SRC_INC_DIRS := $(SRC_DIR) $(INSTALL_INC_DIR)
 SRC_INC_FLAGS:= $(addprefix -I,$(SRC_INC_DIRS))
 SRCS 		 := $(addprefix $(SRC_DIR)/,$(_SRCS))
 ASMS		 := $(addprefix $(SRC_DIR)/,$(_ASMS))
 
 TEST_DIR 	  := $(MOD_DIR)/test
-TEST_INC_DIRS := $(TEST_DIR) $(INC_DIR) $(INSTALL_INC_DIR)
+TEST_INC_DIRS := $(TEST_DIR) $(INSTALL_INC_DIR)
 TEST_INC_FLAGS:= $(addprefix -I,$(TEST_INC_DIRS))
 TEST_SRCS 	  := $(addprefix $(TEST_DIR)/,$(_TEST_SRCS))
 
@@ -126,15 +135,15 @@ test_hdrs.install: $(INSTALL_TEST_HDRS)
 
 .PHONY: lib.dotds test_lib.dotds
 $(C_DOTDS): $(BUILD_DIR)/c_%.d: $(SRC_DIR)/%.c | $(BUILD_DIR)
-	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MT "$(BUILD_DIR)/c_$*.o" -MF $@
 
 $(S_DOTDS): $(BUILD_DIR)/S_%.d: $(SRC_DIR)/%.S | $(BUILD_DIR)
-	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MT "$(BUILD_DIR)/S_$*.o" -MF $@
 
 lib.dotds: $(C_DOTDS) $(S_DOTDS)
 
 $(TEST_DOTDS): $(BUILD_TEST_DIR)/%.d: $(TEST_DIR)/%.c | $(BUILD_TEST_DIR)
-	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MT "$(BUILD_TEST_DIR)/$*.o" -MF $@
 
 test_lib.dotds: $(TEST_DOTDS)
 
@@ -160,35 +169,50 @@ $(C_OBJS): $(BUILD_DIR)/c_%.o: | $(BUILD_DIR)
 $(S_OBJS): $(BUILD_DIR)/S_%.o: | $(BUILD_DIR)
 	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $(SRC_DIR)/$*.S
 
-lib.build: $(BUILD_LIB)
 $(BUILD_LIB): $(C_OBJS) $(S_OBJS) | $(BUILD_DIR)
 	$(AR) rcs $@ $^
 
+lib.build: $(BUILD_LIB)
+
 # Testing Build Targets
 
-$(TEST_OBJS): $(BUILD_TEST_DIR)/%.o: $(TEST_DIR)/%.c $(TEST_HDRS) $(HDRS) | $(BUILD_TEST_DIR)
-	$(C_COMPILER) -c $(CFLAGS) $(TEST_INC_FLAGS) -o $@ $<
+$(TEST_OBJS): $(BUILD_TEST_DIR)/%.o: | $(BUILD_TEST_DIR)
+	$(C_COMPILER) -c $(CFLAGS) $(TEST_INC_FLAGS) -o $@ $(TEST_DIR)/$*.c
 
-test_lib.build: $(BUILD_TEST_LIB)
 $(BUILD_TEST_LIB): $(TEST_OBJS) | $(BUILD_DIR)
 	$(AR) rcs $@ $^
 
-# Install Targets
+test_lib.build: $(BUILD_TEST_LIB)
 
+# 4) Install compiled artifacts!
+#
+# Remember, headers should've been installed earlier!
 
 .PHONY: lib.install test_lib.install
+
+ifneq ($(filter lib.install,$(MAKECMDGOALS)),)
+include $(C_DOTDS) $(S_DOTDS)
+endif
+
+ifneq ($(filter test_lib.install,$(MAKECMDGOALS)),)
+include $(TEST_DOTDS)
+endif
+
+$(INSTALL_LIB): $(BUILD_LIB) | $(INSTALL_DIR)
+	cp $< $@
 
 lib.install: $(INSTALL_LIB) 
 	@echo > /dev/null
 
-$(INSTALL_LIB): $(BUILD_LIB) | $(INSTALL_DIR)
+$(INSTALL_TEST_LIB): $(BUILD_TEST_LIB) | $(INSTALL_DIR)
 	cp $< $@
 
 test_lib.install: $(INSTALL_TEST_LIB)
 	@echo > /dev/null
 
-$(INSTALL_TEST_LIB): $(BUILD_TEST_LIB) | $(INSTALL_DIR)
-	cp $< $@
+# *) Clangd generation and cleanup!
+# 
+# (Can be called out of order just fine)
 
 # Clangd Files
 
@@ -201,17 +225,26 @@ echo "  Add:" >> $1
 $(foreach fl,$(2),echo "  - $(fl)" >> $1;)
 endef
 
+# Here we include $(INC_DIR) just so we can see our changes while editing without needing
+# to call hdrs.install
+
+INC_CLANGD_INC_DIRS := $(INC_DIR) $(INSTALL_INC_DIR)
+INC_CLANGD_INC_FLAGS:= $(addprefix -I,$(INC_CLANGD_INC_DIRS))
 INC_CLANGD := $(INC_DIR)/.clangd
 $(INC_CLANGD):
-	$(call CLANGD_HELPER,$@,$(CFLAGS) $(INC_INC_FLAGS))
+	$(call CLANGD_HELPER,$@,$(CFLAGS) $(INC_CLANGD_INC_FLAGS))
 
+SRC_CLANGD_INC_DIRS := $(SRC_DIR) $(INC_DIR) $(INSTALL_INC_DIR)
+SRC_CLANGD_INC_FLAGS:= $(addprefix -I,$(SRC_CLANGD_INC_DIRS))
 SRC_CLANGD := $(SRC_DIR)/.clangd
 $(SRC_CLANGD):
-	$(call CLANGD_HELPER,$@,$(CFLAGS) $(SRC_INC_FLAGS))
+	$(call CLANGD_HELPER,$@,$(CFLAGS) $(SRC_CLANGD_INC_FLAGS))
 
+TEST_CLANGD_INC_DIRS := $(TEST_DIR) $(INC_DIR) $(INSTALL_INC_DIR)
+TEST_CLANGD_INC_FLAGS:= $(addprefix -I,$(TEST_CLANGD_INC_DIRS))
 TEST_CLANGD := $(TEST_DIR)/.clangd
 $(TEST_CLANGD):
-	$(call CLANGD_HELPER,$@,$(CFLAGS) $(TEST_INC_FLAGS))
+	$(call CLANGD_HELPER,$@,$(CFLAGS) $(TEST_CLANGD_INC_FLAGS))
 
 .PHONY: clangd
 

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -67,6 +67,9 @@ TEST_SRCS 	  := $(addprefix $(TEST_DIR)/,$(_TEST_SRCS))
 
 # Stuff to be built
 
+C_DOTDS	:= $(patsubst %.c,$(BUILD_DIR)/c_%.d,$(_SRCS))
+S_DOTDS	:= $(patsubst %.S,$(BUILD_DIR)/S_%.d,$(_ASMS))
+
 C_OBJS	:= $(patsubst %.c,$(BUILD_DIR)/c_%.o,$(_SRCS))
 S_OBJS	:= $(patsubst %.S,$(BUILD_DIR)/S_%.o,$(_ASMS))
 
@@ -75,7 +78,9 @@ BUILD_LIB	:= $(BUILD_DIR)/$(_LIB)
 INSTALL_LIB	:= $(INSTALL_DIR)/$(_LIB)
 
 BUILD_TEST_DIR := $(BUILD_DIR)/test
-TEST_OBJS	   := $(patsubst %.c,$(BUILD_TEST_DIR)/%.o,$(_TEST_SRCS))
+
+TEST_DOTDS 		:= $(patsubst %.c,$(BUILD_TEST_DIR)/%.d,$(_TEST_SRCS))
+TEST_OBJS 		:= $(patsubst %.c,$(BUILD_TEST_DIR)/%.o,$(_TEST_SRCS))
 
 _TEST_LIB		 := lib$(MOD_NAME)_test.a
 BUILD_TEST_LIB 	 := $(BUILD_TEST_DIR)/$(_TEST_LIB)
@@ -91,6 +96,20 @@ INSTALL_TEST_HDRS := $(addprefix $(INSTALL_TEST_HDRS_DIR)/,$(notdir $(TEST_HDRS)
 
 $(BUILD_DIR) $(BUILD_TEST_DIR) $(INSTALL_DIR):
 	mkdir -p $@
+
+.PHONY: lib.dotds test_lib.dotds
+$(C_DOTDS): $(BUILD_DIR)/c_%.d: $(SRC_DIR)/%.c | $(BUILD_DIR)
+	echo "hello"
+
+$(S_DOTDS): $(BUILD_DIR)/S_%.d: $(SRC_DIR)/%.S | $(BUILD_DIR)
+	echo "hello"
+
+lib.dotds: $(C_DOTDS) $(S_DOTDS)
+
+$(TEST_DOTDS): $(BUILD_TEST_DIR)/%.d: $(TEST_DIR)/%.c $(BUILD_TEST_DIR)
+	echo "hello"
+
+test_lib.dotds: $(TEST_DOTDS)
 
 .PHONY: lib.build test_lib.build
 

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -34,7 +34,6 @@ GIT_TOP := $(shell git rev-parse --show-toplevel)
 # I think it's safe to say that for the entirety of this project I'll be using
 # the 386 tools.
 C_COMPILER := i686-elf-gcc
-ASSEMBLER  := i686-elf-as
 AR 		   := i686-elf-ar
 
 CFLAGS := -m32 -std=gnu99 -ffreestanding -Wall -Wextra -Wpedantic $(EXTRA_CFLAGS)
@@ -56,7 +55,6 @@ TEST_HDRS	 := $(wildcard $(INC_DIR)/$(MOD_NAME)/test/*.h)
 SRC_DIR 	 := $(MOD_DIR)/src
 SRC_INC_DIRS := $(SRC_DIR) $(INC_DIR) $(INSTALL_INC_DIR)
 SRC_INC_FLAGS:= $(addprefix -I,$(SRC_INC_DIRS))
-ASM_INC_FLAGS:= $(addprefix -I ,$(SRC_INC_DIRS))
 SRCS 		 := $(addprefix $(SRC_DIR)/,$(_SRCS))
 ASMS		 := $(addprefix $(SRC_DIR)/,$(_ASMS))
 
@@ -99,15 +97,15 @@ $(BUILD_DIR) $(BUILD_TEST_DIR) $(INSTALL_DIR):
 
 .PHONY: lib.dotds test_lib.dotds
 $(C_DOTDS): $(BUILD_DIR)/c_%.d: $(SRC_DIR)/%.c | $(BUILD_DIR)
-	echo "hello"
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
 
 $(S_DOTDS): $(BUILD_DIR)/S_%.d: $(SRC_DIR)/%.S | $(BUILD_DIR)
-	echo "hello"
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
 
 lib.dotds: $(C_DOTDS) $(S_DOTDS)
 
 $(TEST_DOTDS): $(BUILD_TEST_DIR)/%.d: $(TEST_DIR)/%.c $(BUILD_TEST_DIR)
-	echo "hello"
+	@echo "hello"
 
 test_lib.dotds: $(TEST_DOTDS)
 
@@ -119,7 +117,7 @@ $(C_OBJS): $(BUILD_DIR)/c_%.o: $(SRC_DIR)/%.c $(HDRS) | $(BUILD_DIR)
 	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $<
 
 $(S_OBJS): $(BUILD_DIR)/S_%.o: $(SRC_DIR)/%.S | $(BUILD_DIR)
-	$(ASSEMBLER) $(ASM_INC_FLAGS) -o $@ $<
+	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $<
 
 lib.build: $(BUILD_LIB)
 $(BUILD_LIB): $(C_OBJS) $(S_OBJS) | $(BUILD_DIR)

--- a/src/mod_stub.mk
+++ b/src/mod_stub.mk
@@ -95,6 +95,35 @@ INSTALL_TEST_HDRS := $(addprefix $(INSTALL_TEST_HDRS_DIR)/,$(notdir $(TEST_HDRS)
 $(BUILD_DIR) $(BUILD_TEST_DIR) $(INSTALL_DIR):
 	mkdir -p $@
 
+# The targets in this file are meant to be defined in the very order they should be invoked!
+
+# 1) Header installation
+#
+# This should be done first for all modules! .d file generation must be able to discover ALL
+# referenced headers!
+
+$(INSTALL_HDRS_DIR) $(INSTALL_TEST_HDRS_DIR):
+	mkdir -p $@
+
+.PHONY: hdrs.install test_hdrs.install
+
+$(INSTALL_HDRS): $(INSTALL_HDRS_DIR)/%.h: $(INC_DIR)/$(MOD_NAME)/%.h | $(INSTALL_HDRS_DIR)
+	cp $< $@
+
+hdrs.install: $(INSTALL_HDRS)
+	@echo > /dev/null
+
+$(INSTALL_TEST_HDRS): $(INSTALL_TEST_HDRS_DIR)/%.h: $(INC_DIR)/$(MOD_NAME)/test/%.h | $(INSTALL_TEST_HDRS_DIR)
+	cp $< $@
+
+test_hdrs.install: $(INSTALL_TEST_HDRS)
+	@echo > /dev/null
+
+# 2) .d File generation
+#
+# Again, this will only succeed if ALL referenced headers (even those outside this module)
+# can be found via the include path!
+
 .PHONY: lib.dotds test_lib.dotds
 $(C_DOTDS): $(BUILD_DIR)/c_%.d: $(SRC_DIR)/%.c | $(BUILD_DIR)
 	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
@@ -104,20 +133,32 @@ $(S_DOTDS): $(BUILD_DIR)/S_%.d: $(SRC_DIR)/%.S | $(BUILD_DIR)
 
 lib.dotds: $(C_DOTDS) $(S_DOTDS)
 
-$(TEST_DOTDS): $(BUILD_TEST_DIR)/%.d: $(TEST_DIR)/%.c $(BUILD_TEST_DIR)
-	@echo "hello"
+$(TEST_DOTDS): $(BUILD_TEST_DIR)/%.d: $(TEST_DIR)/%.c | $(BUILD_TEST_DIR)
+	$(C_COMPILER) $(SRC_INC_FLAGS) -E $< -MM -MF $@
 
 test_lib.dotds: $(TEST_DOTDS)
 
+# 3) Object compilation and library creation!
+#
+# We include the .d files conditionally! This way, are not attempted to be generated for targets
+# which don't require them!
+
 .PHONY: lib.build test_lib.build
 
-# NOTE: We only rebuild on modification to headers in this module.
-# We treat installed dependencies in the install dir as unchanging.
-$(C_OBJS): $(BUILD_DIR)/c_%.o: $(SRC_DIR)/%.c $(HDRS) | $(BUILD_DIR)
-	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $<
+ifneq ($(filter lib.build,$(MAKECMDGOALS)),)
+include $(C_DOTDS) $(S_DOTDS)
+endif
 
-$(S_OBJS): $(BUILD_DIR)/S_%.o: $(SRC_DIR)/%.S | $(BUILD_DIR)
-	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $<
+ifneq ($(filter test_lib.build,$(MAKECMDGOALS)),)
+include $(TEST_DOTDS)
+endif
+
+# .d files will declare all significant dependencies!
+$(C_OBJS): $(BUILD_DIR)/c_%.o: | $(BUILD_DIR)
+	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $(SRC_DIR)/$*.c
+
+$(S_OBJS): $(BUILD_DIR)/S_%.o: | $(BUILD_DIR)
+	$(C_COMPILER) -c $(CFLAGS) $(SRC_INC_FLAGS) -o $@ $(SRC_DIR)/$*.S
 
 lib.build: $(BUILD_LIB)
 $(BUILD_LIB): $(C_OBJS) $(S_OBJS) | $(BUILD_DIR)
@@ -135,27 +176,12 @@ $(BUILD_TEST_LIB): $(TEST_OBJS) | $(BUILD_DIR)
 # Install Targets
 
 
-$(INSTALL_HDRS_DIR) $(INSTALL_TEST_HDRS_DIR):
-	mkdir -p $@
-
-.PHONY: hdrs.install lib.install test_hdrs.install test_lib.install
-
-hdrs.install: $(INSTALL_HDRS)
-	@echo > /dev/null
-
-$(INSTALL_HDRS): $(INSTALL_HDRS_DIR)/%.h: $(INC_DIR)/$(MOD_NAME)/%.h | $(INSTALL_HDRS_DIR)
-	cp $< $@
+.PHONY: lib.install test_lib.install
 
 lib.install: $(INSTALL_LIB) 
 	@echo > /dev/null
 
 $(INSTALL_LIB): $(BUILD_LIB) | $(INSTALL_DIR)
-	cp $< $@
-
-test_hdrs.install: $(INSTALL_TEST_HDRS)
-	@echo > /dev/null
-
-$(INSTALL_TEST_HDRS): $(INSTALL_TEST_HDRS_DIR)/%.h: $(INC_DIR)/$(MOD_NAME)/test/%.h | $(INSTALL_TEST_HDRS_DIR)
 	cp $< $@
 
 test_lib.install: $(INSTALL_TEST_LIB)


### PR DESCRIPTION
This is a pretty significant refactor of my build system to include .d files!

The benefit is that rebuilds are guaranteed to take into account all necessary prerequisites! Before this, we'd only rebuild an object file if any of the headers within its module had changed!

If a source file included a header from a different module, rebuilding would not occur if the external header changed. .d files change this!