### PR TITLE
Temporary GFX in Schema

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -59,10 +59,10 @@ $(BUILD_DIR) $(INCLUDE_DIR) $(INSTALL_DIR):
 
 ####################################################################################################
 
-FERNCONF_VERSION := 0.1.8
+FERNCONF_VERSION := 0.1.9
 VENV_ACTIVATE := $(VENV_DIR)/bin/activate
 
-$(VENV_DIR):
+$(VENV_DIR): $(THIS_FILE)
 	mkdir -p $@
 	python3 -m venv $(VENV_DIR)
 	. $(VENV_ACTIVATE) && \
@@ -104,41 +104,6 @@ CONFIGS := $(CONFIG_C) $(CONFIG_S) $(CONFIG_LD) $(CONFIG_MK)
 
 ####################################################################################################
 
-# Layout Header and LD script generation.
-# All ranges below are inclusive! (These all must be numeric constants)
-
-# TODO: Add graphics settings into config schema and remove need for these old os defs files 
-# entirely!
-
-FERNOS_GFX_WIDTH  := 1024
-FERNOS_GFX_HEIGHT := 768
-FERNOS_GFX_BPP    := 32
-
-# All Important OS Definitions
-OS_DEFS :=   FERNOS_GFX_WIDTH FERNOS_GFX_HEIGHT \
-			 FERNOS_GFX_BPP
-
-C_MACRO_GEN = echo "\#define $1 $($1)UL" >> $@;
-LD_DEF_GEN = echo "$1 = ($($1));" >> $@; 
-S_DEF_GEN = echo "\#define $1 $($1)" >> $@; 
-
-OS_DEFS_H := $(INCLUDE_DIR)/os_defs.h
-$(OS_DEFS_H): $(THIS_FILE) | $(INCLUDE_DIR)
-	echo "#pragma once" > $@
-	$(foreach def,$(OS_DEFS),$(call C_MACRO_GEN,$(def)))
-
-OS_DEFS_LD := $(INSTALL_DIR)/os_defs.ld
-$(OS_DEFS_LD): $(THIS_FILE) | $(INSTALL_DIR)
-	rm $@; touch $@;
-	$(foreach def,$(OS_DEFS),$(call LD_DEF_GEN,$(def)))
-
-OS_DEFS_S := $(INCLUDE_DIR)/s_os_defs.h
-$(OS_DEFS_S): $(THIS_FILE) | $(INCLUDE_DIR)
-	rm $@; touch $@;
-	$(foreach def,$(OS_DEFS),$(call S_DEF_GEN,$(def)))
-
-####################################################################################################
-
 # A helper macro invoking module specific make targets!
 # This expects that $* resolves to the name of a module.
 MOD_MAKE = $(MY_MAKE) -C $(SRC_DIR)/$* BUILD_DIR=$(BUILD_DIR)/mods/$* INSTALL_DIR=$(INSTALL_DIR)
@@ -152,7 +117,7 @@ $(HDRS_INSTALL_TARS): hdrs.install.%:
 	$(MOD_MAKE) hdrs.install test_hdrs.install 
 
 .PHONY: hdrs.install $(HDRS_INSTALL_TARS)
-hdrs.install: $(HDRS_INSTALL_TARS) $(CONFIG_C) $(CONFIG_S) $(OS_DEFS_H) $(OS_DEFS_S) 
+hdrs.install: $(HDRS_INSTALL_TARS) $(CONFIG_C) $(CONFIG_S)
 	$(call DONE_MSG,Headers Installed)
 
 # Install Libraries

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -243,7 +243,13 @@ FOS_CORE = FCSchemaStruct(
         # Similarly, must be able to fit a plugin id into a single byte!
         ("MAX_PLUGINS", fos_bound_int(1, 256).with_default_any(16).with_comment([
             "Guarnateed to be <= 256"
-        ]))
+        ])),
+
+        # TODO: Add Plugin section to schema so that these gfx definitions don't need to
+        # be here in "CORE".
+        ("GFX_WIDTH", FCS_INT.const_any(1024)),
+        ("GFX_HEIGHT", FCS_INT.const_any(768)),
+        ("GFX_BPP", FCS_INT.const_any(32))
     ]
 
     # I had planned to derive the start and end of the kernel stack here.

--- a/src/k_startup/include/k_startup/page.h
+++ b/src/k_startup/include/k_startup/page.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "k_sys/page.h"
-#include "os_defs.h"
+
 #include "s_util/misc.h"
 #include "s_util/err.h"
 #include <stdbool.h>

--- a/src/k_startup/src/boot.S
+++ b/src/k_startup/src/boot.S
@@ -1,5 +1,5 @@
 
-#include "s_os_defs.h"
+
 #include "s_config.h"
 
 .section .multiboot
@@ -23,9 +23,9 @@ gfx_tag:
     .short 0
     .long  20
 
-    .long  FERNOS_GFX_WIDTH
-    .long  FERNOS_GFX_HEIGHT
-    .long  FERNOS_GFX_BPP
+    .long  FC_CORE_GFX_WIDTH
+    .long  FC_CORE_GFX_HEIGHT
+    .long  FC_CORE_GFX_BPP
 
     .long 0  // pad
 

--- a/src/k_startup/src/gfx.c
+++ b/src/k_startup/src/gfx.c
@@ -1,7 +1,7 @@
 
 #include "k_startup/gfx.h"
 
-#include "os_defs.h"
+
 #include "k_sys/debug.h"
 #include "s_util/str.h"
 #include "s_gfx/mono_fonts.h"
@@ -36,11 +36,11 @@ gfx_screen_t * const SCREEN = &screen;
  * Remember that `init_screen` will fail if the memory mapped buffer doesnt have
  * pixels in these dimmensions.
  */
-static gfx_color_t back_buffer_arr[FERNOS_GFX_HEIGHT][FERNOS_GFX_WIDTH];
+static gfx_color_t back_buffer_arr[FC_CORE_GFX_HEIGHT][FC_CORE_GFX_WIDTH];
 
 static gfx_buffer_t back_buffer = {
-    .width = FERNOS_GFX_WIDTH,
-    .height = FERNOS_GFX_HEIGHT,
+    .width = FC_CORE_GFX_WIDTH,
+    .height = FC_CORE_GFX_HEIGHT,
     .buffer = (gfx_color_t *)back_buffer_arr
 };
 
@@ -119,8 +119,8 @@ fernos_error_t init_screen(const m2_info_start_t *m2_info) {
     // Confirm the screen is setup as expected! 
     // (Remember, the final page of the epilogue will be unmappable in kernel space)
     if (fb_tag->addr < FC_CORE_PMEM_BODY_END || end > ALIGN(0xFFFFFFFF, M_4K) ||
-            fb_tag->width != FERNOS_GFX_WIDTH ||
-            fb_tag->height != FERNOS_GFX_HEIGHT || fb_tag->bpp != FERNOS_GFX_BPP) {
+            fb_tag->width != FC_CORE_GFX_WIDTH ||
+            fb_tag->height != FC_CORE_GFX_HEIGHT || fb_tag->bpp != FC_CORE_GFX_BPP) {
 
         // An error at this point means that a frame buffer was setup, but not in the expected
         // configuration. So, let's just write 0xFF's to the entire buffer area!
@@ -157,8 +157,8 @@ void gfx_direct_term_render(void) {
     const int32_t height = DIRECT_TERM_H_SCALE * (int32_t)(DIRECT_TERM_FONT->char_height) * DIRECT_TERM_ROWS;
 
     // Let's center this bad boy.
-    const int32_t x = (FERNOS_GFX_WIDTH - width) / 2;
-    const int32_t y = (FERNOS_GFX_HEIGHT - height) / 2;
+    const int32_t x = (FC_CORE_GFX_WIDTH - width) / 2;
+    const int32_t y = (FC_CORE_GFX_HEIGHT - height) / 2;
 
     gfx_draw_term_buffer(BACK_BUFFER, NULL, NULL, 
             DIRECT_TERM, DIRECT_TERM_FONT, BASIC_ANSI_PALETTE, 

--- a/src/k_startup/src/kernel.c
+++ b/src/k_startup/src/kernel.c
@@ -170,7 +170,7 @@ static void init_kernel_plugins(void) {
     //
     // Remember, for kernel managed windows, screen tearing is never a problem!
     // One buffer is just fine!
-    window_t *root_window = new_da_window_qgrid(new_da_dynamic_gfx_manager_single(FERNOS_GFX_WIDTH, FERNOS_GFX_HEIGHT));
+    window_t *root_window = new_da_window_qgrid(new_da_dynamic_gfx_manager_single(FC_CORE_GFX_WIDTH, FC_CORE_GFX_HEIGHT));
     if (!root_window) {
         gfx_direct_fatal("Failed to allocate root window");
     }

--- a/src/k_startup/src/plugin_gfx.c
+++ b/src/k_startup/src/plugin_gfx.c
@@ -7,7 +7,7 @@
 #include "s_gfx/window_dummy.h"
 #include "k_startup/page_helpers.h"
 #include "s_util/ansi.h"
-#include "os_defs.h"
+
 
 fernos_error_t init_window_gfx_base(window_gfx_base_t *win, gfx_manager_t *gm, const window_impl_t *impl, allocator_t *al, ring_t *sch) {
     if (!win || !gm || !impl || !al || !sch) {
@@ -26,10 +26,10 @@ fernos_error_t init_window_gfx_base(window_gfx_base_t *win, gfx_manager_t *gm, c
 
     const window_attrs_t attrs = {
         .min_width = 0,
-        .max_width = FERNOS_GFX_WIDTH,
+        .max_width = FC_CORE_GFX_WIDTH,
 
         .min_height = 0,
-        .max_height = FERNOS_GFX_HEIGHT
+        .max_height = FC_CORE_GFX_HEIGHT
     };
     init_window_base((window_t *)win, gm, &attrs, impl);
     *(allocator_t **)&(win->al) = al;
@@ -603,8 +603,8 @@ static window_gfx_gm_t *new_window_gfx_gm(kernel_state_t *ks) {
     window_gfx_gm_t *wggm = al_malloc(ks->al, sizeof(window_gfx_gm_t));
 
     gfx_color_t *banks[2];
-    ks_kernel_cmd(ks, PLG_SHARED_MEM_ID, PLG_SHM_KCID_NEW_SHM, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT, (uint32_t)(banks + 0), 0, 0);
-    ks_kernel_cmd(ks, PLG_SHARED_MEM_ID, PLG_SHM_KCID_NEW_SHM, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT, (uint32_t)(banks + 1), 0, 0);
+    ks_kernel_cmd(ks, PLG_SHARED_MEM_ID, PLG_SHM_KCID_NEW_SHM, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT, (uint32_t)(banks + 0), 0, 0);
+    ks_kernel_cmd(ks, PLG_SHARED_MEM_ID, PLG_SHM_KCID_NEW_SHM, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT, (uint32_t)(banks + 1), 0, 0);
 
     if (!wggm || !banks[0] || !banks[1]) {
         ks_kernel_cmd(ks, PLG_SHARED_MEM_ID, PLG_SHM_KCID_SHM_DEC, (uint32_t)(banks[1]), 0, 0, 0);
@@ -614,8 +614,8 @@ static window_gfx_gm_t *new_window_gfx_gm(kernel_state_t *ks) {
     }
 
     // Start both banks a black!
-    mem_set(banks[0], 0, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT);
-    mem_set(banks[1], 0, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT);
+    mem_set(banks[0], 0, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT);
+    mem_set(banks[1], 0, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT);
 
     init_gfx_manager_base((gfx_manager_t *)wggm, &WINDOW_GFX_GM_IMPL, 0, 0);
     *(kernel_state_t **)&(wggm->ks) = ks;
@@ -657,7 +657,7 @@ static void wggm_swap(gfx_manager_t *gm) {
 
 static fernos_error_t wggm_resize(gfx_manager_t *gm, uint16_t width, uint16_t height) {
     (void)gm;
-    if ((uint32_t)width * (uint32_t)height > FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT) {
+    if ((uint32_t)width * (uint32_t)height > FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT) {
         return FOS_E_NO_SPACE;
     }
     return FOS_E_SUCCESS;
@@ -890,7 +890,7 @@ plugin_t *new_plugin_gfx(kernel_state_t *ks, window_t *root_window) {
 
     // We actually allow the `root_window` resize to fail.
     // As long as the window is still active, we are good!
-    err = win_resize(root_window, FERNOS_GFX_WIDTH, FERNOS_GFX_HEIGHT);
+    err = win_resize(root_window, FC_CORE_GFX_WIDTH, FC_CORE_GFX_HEIGHT);
 
     if (err != FOS_E_INACTIVE) {
         err = win_fwd_event(root_window, (window_event_t) {

--- a/src/u_startup/include/u_startup/syscall_gfx.h
+++ b/src/u_startup/include/u_startup/syscall_gfx.h
@@ -5,7 +5,7 @@
 #include "s_gfx/window.h"
 #include "s_gfx/gfx_manager.h"
 
-#include "os_defs.h"
+
 
 /**
  * Create a self managed dummy window.
@@ -45,7 +45,7 @@ fernos_error_t sc_gfx_new_terminal(handle_t *h, const gfx_term_buffer_attrs_t *a
  * must be closed from the desktop. On window cleanup, the shared memory areas just have their
  * kernel reference count decremented! They will still persist in userspace until being 
  * manually unmapped!
- * 4. The created bufs will each be fixed in size. (FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT * sizeof(gfx_color_t))
+ * 4. The created bufs will each be fixed in size. (FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT * sizeof(gfx_color_t))
  */
 fernos_error_t sc_gfx_new_gfx_window(handle_t *h, gfx_color_t *(*shm_buf)[2]);
 

--- a/src/u_startup/test/syscall_gfx.c
+++ b/src/u_startup/test/syscall_gfx.c
@@ -79,12 +79,12 @@ static bool test_lasting_shms(void) {
     // Here, even though the handle is closed, we should still be able to read/write to 
     // shared buffers!
     
-    mem_set(bufs[0], 0x1F, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT);
-    mem_set(bufs[1], 0x3F, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT);
+    mem_set(bufs[0], 0x1F, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT);
+    mem_set(bufs[1], 0x3F, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT);
 
     sc_shm_close_shm(bufs[1]);
 
-    mem_set(bufs[0], 0x0F, sizeof(gfx_color_t) * FERNOS_GFX_WIDTH * FERNOS_GFX_HEIGHT);
+    mem_set(bufs[0], 0x0F, sizeof(gfx_color_t) * FC_CORE_GFX_WIDTH * FC_CORE_GFX_HEIGHT);
 
     sc_shm_close_shm(bufs[0]);
 
@@ -110,7 +110,7 @@ static bool test_gfx_fork(void) {
             for (size_t j = 0; j < 5; j++) {
                 TEST_SUCCESS(sc_gfx_read_event_single(h, &ev));
 
-                mem_set(bufs[0] + (6 * FERNOS_GFX_WIDTH * i), 0xF + (j * 16), 6 * FERNOS_GFX_WIDTH * sizeof(gfx_color_t));
+                mem_set(bufs[0] + (6 * FC_CORE_GFX_WIDTH * i), 0xF + (j * 16), 6 * FC_CORE_GFX_WIDTH * sizeof(gfx_color_t));
             }
 
             // By exiting handles and shms should be closed just fine!


### PR DESCRIPTION
This just removes the need for the primitive `os_defs` files generated entirely via Make.

Now gfx stuff is temporarily stored in the `CORE` section of the config. I'll change this once I figure how to list plugin specific options in the config!