### PR TITLE
Better physical free list detection!

### DIFF
--- a/src/k_startup/include/k_startup/page.h
+++ b/src/k_startup/include/k_startup/page.h
@@ -12,9 +12,9 @@
  * Here are all the section layouts as defined in the linker script.
  *
  * NOTE: end is EXCLUSIVE!
- *
- * The ends is os_defs are INCLUSIVE!
  */
+
+extern uint8_t _static_area_start[];
 
 extern uint8_t _sys_tables_start[];
 extern uint8_t _sys_tables_end[];

--- a/src/k_startup/include/k_startup/page.h
+++ b/src/k_startup/include/k_startup/page.h
@@ -16,6 +16,9 @@
 
 extern uint8_t _static_area_start[];
 
+extern uint8_t _multiboot_start[];
+extern uint8_t _multiboot_end[];
+
 extern uint8_t _sys_tables_start[];
 extern uint8_t _sys_tables_end[];
 

--- a/src/k_startup/src/page.c
+++ b/src/k_startup/src/page.c
@@ -51,40 +51,87 @@ uint8_t free_kernel_pages[NUM_FREE_KERNEL_PAGES][M_4K] __attribute__((aligned(NU
 static pt_entry_t free_kernel_page_pt[1024] __attribute__((aligned(M_4K)));
 static pt_entry_t *free_kernel_page_ptes[NUM_FREE_KERNEL_PAGES];
 
-
-/**
- * This is just the range to use to set up the initial free list.
- * After initialization, pages outside this range can be added to the free list
- * without consequence. (Just be careful)
+/*
+ * If you look in c_config.h, you'll see many areas prefixed with "VMEM". These outline
+ * what memory will look like when virtual memory is enabled.
+ *
+ * Only two of those areas (not even entirely) are actually identity mapped though!
+ *
+ * [_static_area_start, _static_area_end) 
+ * A large area of physical memory is reserved for loadable contents of the kernel elf.
+ * Most likely though, the area needed is much smaller than what is reserved.
+ * We use the _static_area pointers (declared in the linker script) to determine what pages
+ * were actually written to.
+ *
+ * [FC_CORE_KSTACK_START, FC_CORE_KSTACK_END)
+ * While probably not 100% required, it made my life much easier for the whole kernel stack area
+ * to be identity mapped in EVERY page table. (marked as supervisor only)
+ *
+ * The pages all live within the range FC_CORE_PMEM_BODY.
+ * So, all physical pages within FC_CORE_PMEM_BODY which are NOT part of the above two ranges,
+ * will be added to the free list!
+ *
+ * NOTE: The logic for this used to be much simpler as the _static_area was always the very 
+ * beginning of the BODY, and the kernel stack was always very end.
+ * Now though with config.json files, these two ranges can appear anywhere within the body!
  */
-#define INITIAL_FREE_AREA_START ((phys_addr_t)_static_area_end) 
-#define INITIAL_FREE_AREA_END  ((phys_addr_t)FC_CORE_KSTACK_START) // Exclusive end.
 
 static phys_addr_t free_list_head = NULL_PHYS_ADDR;
 static uint32_t free_list_len = 0;
 
 static fernos_error_t _init_free_list(void) {
-    CHECK_ALIGN(INITIAL_FREE_AREA_START, M_4K);
-    CHECK_ALIGN(INITIAL_FREE_AREA_END, M_4K);
+    // These checks are redundant, but whatever.
+    CHECK_ALIGN((phys_addr_t)_static_area_start, M_4K);
+    CHECK_ALIGN((phys_addr_t)_static_area_end, M_4K);
+    CHECK_ALIGN(FC_CORE_KSTACK_START, M_4K);
+    CHECK_ALIGN(FC_CORE_KSTACK_END, M_4K);
 
-    if (INITIAL_FREE_AREA_START == INITIAL_FREE_AREA_END) {
-        return FOS_E_SUCCESS;
+    typedef struct {
+        phys_addr_t start;
+        phys_addr_t end;
+    } page_range_t;
+
+    const page_range_t static_area_range = {
+        (phys_addr_t)_static_area_start, 
+        (phys_addr_t)_static_area_end
+    };
+
+    const page_range_t kstack_range = {
+        FC_CORE_KSTACK_START, 
+        FC_CORE_KSTACK_END
+    };
+
+    // how the boys back home sort 2 element lists.
+    const page_range_t iareas[2] = {
+        static_area_range.start < kstack_range.start ? static_area_range : kstack_range,
+        static_area_range.start < kstack_range.start ? kstack_range : static_area_range
+    };
+
+    // realize that it is very possible 1 or 2 of these free areas are actually empty!
+    const page_range_t free_areas[3] = {
+        {FC_CORE_PMEM_BODY_START, iareas[0].start},
+        {iareas[0].end, iareas[1].start},
+        {iareas[1].end, FC_CORE_PMEM_BODY_END}
+    };
+
+    const size_t num_free_areas = sizeof(free_areas) / sizeof(free_areas[0]);
+    for (size_t i = 0; i < num_free_areas; i++) {
+        page_range_t free_area = free_areas[i];
+
+        if (free_area.start == free_area.end) {
+            continue; // skip empty ranges!
+        }
+
+        for (phys_addr_t p = free_area.start; p < free_area.end - M_4K; p += M_4K) {
+            *(phys_addr_t *)p = p + M_4K;
+        }
+        
+        // The final page in the area will point to the current free list head.
+        *(phys_addr_t *)(free_area.end - M_4K) = free_list_head;
+        free_list_head = free_area.start;
+        free_list_len += (free_area.end - free_area.start) / M_4K;
     }
 
-    if (INITIAL_FREE_AREA_END < INITIAL_FREE_AREA_START) {
-        return FOS_E_INVALID_RANGE;
-    }
-
-    for (phys_addr_t iter = INITIAL_FREE_AREA_START; iter < INITIAL_FREE_AREA_END; iter += M_4K) {
-        *(phys_addr_t *)iter = iter + M_4K;
-    }
-
-    // Set final link to NULL.
-    *(phys_addr_t *)(INITIAL_FREE_AREA_END - M_4K) = NULL_PHYS_ADDR;
-    
-    free_list_head = INITIAL_FREE_AREA_START;
-    free_list_len = (INITIAL_FREE_AREA_END - INITIAL_FREE_AREA_START) / M_4K;
-    
     return FOS_E_SUCCESS;
 }
 

--- a/src/k_startup/src/page.c
+++ b/src/k_startup/src/page.c
@@ -261,10 +261,20 @@ static fernos_error_t _init_kernel_pd(void) {
      *
      * Remeber that the prologue does NOT contain the very first physical page!
      * Similarly, the epilogue does NOT contain the very last physical page!
+     *
+     * Also, I believe right now, in kernel mode, the writeable bit in ptes has no effect.
+     * However, I think there is a way to change this if I really want one day!
      */
 
     PROP_ERR(_place_range(pd, (uint8_t *)(FC_CORE_PMEM_PROLOGUE_START), (const uint8_t *)(FC_CORE_PMEM_PROLOGUE_END), 
                 _R_IDENTITY | _R_WRITEABLE | _R_DONT_CACHE));    
+
+    /*
+     * This area contains just the headers declared in boot.S.
+     * Grub will give a pointer to the requested multiboot structures at runtime.
+     * These structures will likely live in the prologue.
+     */
+    PROP_ERR(_place_range(pd, _multiboot_start, _multiboot_end, _R_IDENTITY));
 
     PROP_ERR(_place_range(pd, _sys_tables_start, _sys_tables_end, _R_WRITEABLE | _R_IDENTITY));
 

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -44,10 +44,17 @@ SECTIONS
      * Each table gets one full page, which should be more than enough!
      */
     
+    .misc.start : {
+        . = ALIGN(4K);
+        _static_area_start = .;
+    } > fernos_kernel_area
+    
     .multiboot : {
         . = ALIGN(4K);
+        _multiboot_start = .;
 		*(.multiboot)
         . = ALIGN(4K);
+        _multiboot_end = .;
     } > fernos_kernel_area
     
     .sys_tables : {
@@ -153,7 +160,7 @@ SECTIONS
         _data_user_end = .;
     } > fernos_kernel_area
 
-    .misc : {
+    .misc.end : {
         . = ALIGN(4K);
         _static_area_end = .;
     } > fernos_kernel_area


### PR DESCRIPTION
Before this PR, the physical page free list would just be all the physical pages from the end of the loaded elf area to the beginning of the stack area.

This method is now insufficient as the location of the stack and elf areas can be changed via `config.json`.

This PR add logic for calculating areas within `PMEM_BODY` which do not belong to the stack or elf areas. These unused areas all are added to the free list!